### PR TITLE
Fix Emergency Cancel Detection with Automatic Test Mode Cycling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,16 @@ Configure `INREACH_MAP_SHARES` with your Garmin InReach MapShare URLs:
       "Password": "optional-password",
       "CoTType": "a-f-G"
     }
-  ]
+  ],
+  "EMERGENCY_TIMEOUT_HOURS": 6
 }
 ```
+
+**Emergency Alert System:**
+- Automatically generates `b-a-o-tbl` (911 Alert) CoTs when devices enter emergency mode
+- Generates `b-a-o-can` (Cancel Alert) CoTs when devices exit emergency mode
+- Auto-cancels emergency alerts after `EMERGENCY_TIMEOUT_HOURS` if device goes offline (default: 6 hours)
+- Emergency CoTs are separate from device position CoTs, following ATAK emergency handling standards
 
 #### Test Mode
 For development, testing or training without physical devices, enable test mode (only available when `ENABLE_TEST_MODE = true` in build configuration):
@@ -56,7 +63,7 @@ For development, testing or training without physical devices, enable test mode 
       "MovementPattern": "stationary",
       "Speed": 0,
       "EmergencyMode": true,
-      "MessageInterval": 5,
+      "MessageInterval": 1,
       "CoTType": "a-f-G"
     }
   ]
@@ -74,6 +81,15 @@ For development, testing or training without physical devices, enable test mode 
 - `inReach Explorer`
 - `inReach SE+`
 - `inReach Messenger`
+
+**Emergency Testing:**
+When `EmergencyMode: true` is set on a test device, it automatically cycles between emergency and normal states:
+- **Minutes 0-4**: Normal operation (`In Emergency: False`)
+- **Minutes 5-9**: Emergency active (`In Emergency: True`) → Generates `b-a-o-tbl` alert
+- **Minutes 10-14**: Emergency cancelled (`In Emergency: False`) → Generates `b-a-o-can` alert
+- **Minutes 15-19**: Emergency active again, and so on...
+
+This provides automatic testing of the complete emergency alert lifecycle without manual intervention.
 
 **Note:** Test mode configuration options are only visible in the CloudTAK UI when the ETL is built with `ENABLE_TEST_MODE = true`. Production builds should set this to `false` to hide test functionality.
 


### PR DESCRIPTION
## Problem
Emergency cancel alerts (`b-a-o-can`) were not being generated in test mode due to ephemeral state resets when configuration changes were made. When users changed `EmergencyMode` from `true` to `false` to test cancellation, the ephemeral state containing the previous emergency status was lost, preventing cancel detection.

## Root Cause
The emergency cancel detection logic relies on comparing current emergency state with previous state stored in ephemeral storage. When configuration changes reset ephemeral state, `wasEmergency` becomes `false`, breaking the cancel detection condition.

## Solution
Implemented **automatic emergency state cycling** for test devices when `EmergencyMode: true`:

- **Minutes 0-4**: Emergency OFF (`In Emergency: False`)
- **Minutes 5-9**: Emergency ON (`In Emergency: True`) → Generates `b-a-o-tbl`
- **Minutes 10-14**: Emergency OFF (`In Emergency: False`) → Generates `b-a-o-can`
- **Minutes 15-19**: Emergency ON (`In Emergency: True`) → Generates `b-a-o-tbl`
- **Continues cycling every 5 minutes**

## Benefits
- **No manual intervention required** - Automatically tests both emergency start and cancel
- **Predictable behavior** - 5-minute cycles make it easy to demonstrate and verify
- **Realistic testing** - Shows complete emergency alert lifecycle
- **No orphaned alerts** - Always properly cancels emergencies
- **Survives state resets** - Cycling is time-based, not state-dependent

## Testing
- ✅ Emergency alerts generated every 5 minutes (minutes 5-9, 15-19, etc.)
- ✅ Cancel alerts generated every 5 minutes (minutes 10-14, 20-24, etc.)
- ✅ Proper CoT types: `b-a-o-tbl` for emergency, `b-a-o-can` for cancel
- ✅ Emergency state cycling survives ephemeral state resets
- ✅ Real device functionality unchanged

## Usage
Set test device configuration with `EmergencyMode: true` and `MessageInterval: 1`. The device will automatically cycle between emergency and normal states, generating appropriate alerts for testing and demonstration purposes.

## Breaking Changes
None - this only affects test mode behavior when `EmergencyMode: true` is explicitly configured.
