### PR TITLE
Add Custom Icon Support and 15-Minute Stale Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,23 @@ Configure `INREACH_MAP_SHARES` with your Garmin InReach MapShare URLs:
       "ShareId": "your-share-id-or-url",
       "CallSign": "Operator Name",
       "Password": "optional-password",
-      "CoTType": "a-f-G"
+      "CoTType": "a-f-G",
+      "IconsetPath": "Lifelines/communications_infrastructure-gray-halo.png"
     }
   ],
   "EMERGENCY_TIMEOUT_HOURS": 6
+}
+```
+
+**Custom Icons:**
+- `IconsetPath`: Path to custom icon within an iconset (e.g., "Lifelines/communications_infrastructure-gray-halo.png")
+
+**Example with Custom Icon:**
+```json
+{
+  "ShareId": "your-share-id",
+  "CallSign": "Communications Team",
+  "IconsetPath": "Lifelines/communications_infrastructure-gray-halo.png"
 }
 ```
 
@@ -52,7 +65,8 @@ For development, testing or training without physical devices, enable test mode 
       "Speed": 5,
       "EmergencyMode": false,
       "MessageInterval": 10,
-      "CoTType": "a-f-G"
+      "CoTType": "a-f-G",
+      "IconsetPath": "Lifelines/communications_infrastructure-gray-halo.png"
     },
     {
       "IMEI": "300434030910341",
@@ -64,7 +78,8 @@ For development, testing or training without physical devices, enable test mode 
       "Speed": 0,
       "EmergencyMode": true,
       "MessageInterval": 1,
-      "CoTType": "a-f-G"
+      "CoTType": "a-f-G",
+      "IconsetPath": "Lifelines/communications_infrastructure-gray-halo.png"
     }
   ]
 }


### PR DESCRIPTION
## Summary
This PR adds custom icon support to the InReach ETL and sets the stale time to 15 minutes for all CoT features.

## Changes Made

### ✨ New Features
- **Custom Icon Support**: Added `IconsetPath` configuration field for both real devices and test devices
- **15-Minute Stale Time**: All CoT features now have a 15-minute stale time from their timestamp

### 🔧 Technical Details
- Added `IconsetPath` to Share interface and schema definitions
- Implemented proper iconset UUID format: `de450cbf-2ffc-47fb-bd2b-ba2db89b035e:path`
- Updated test device processing to support custom icons
- Added stale time calculation: `timestamp + 15 minutes`

### 📚 Documentation
- Updated README with custom icon configuration examples
- Added example showing `IconsetPath` usage
- Documented iconset path format

### 🧪 Testing
- ✅ Build passes
- ✅ ESLint passes
- ✅ Custom icons working in test mode
- ✅ 15-minute stale time applied correctly

## Configuration Example

```json
{
  "INREACH_MAP_SHARES": [
    {
      "ShareId": "your-share-id",
      "CallSign": "Communications Team", 
      "IconsetPath": "Lifelines/communications_infrastructure-gray-halo.png"
    }
  ]
}
